### PR TITLE
Allow more elements inside a label of .btn-group

### DIFF
--- a/lib/button-native.js
+++ b/lib/button-native.js
@@ -95,7 +95,7 @@
 				function triggerChange(t) { t.dispatchEvent(changeEvent) }
 
 				//manage the dom manipulation
-				if ( input.type === 'checkbox' ) { //checkboxes
+				if ( input && input.type === 'checkbox' ) { //checkboxes
 
 					if ( input.checked )  {
 						label.classList.remove('active');
@@ -108,7 +108,7 @@
 					triggerChange(self.btn) //trigger the change for the btn-group
 				}
 
-				if ( input.type === 'radio' ){ // radio buttons
+				if ( input && input.type === 'radio' ){ // radio buttons
 
 					if ( !input.checked ) { // don't trigger if already active
 						label.classList.add('active');

--- a/lib/button-native.js
+++ b/lib/button-native.js
@@ -81,6 +81,7 @@
 				var target = e.currentTarget || e.srcElement; // the button group, the target of the Button function
 				var labels = target.querySelectorAll('.btn'); // all the button group buttons
 				var input = label.getElementsByTagName('INPUT')[0];
+				if ( !input ) return;
 
 				// The built in event that will be triggered on demand
 				var changeEvent;
@@ -95,7 +96,7 @@
 				function triggerChange(t) { t.dispatchEvent(changeEvent) }
 
 				//manage the dom manipulation
-				if ( input && input.type === 'checkbox' ) { //checkboxes
+				if ( input.type === 'checkbox' ) { //checkboxes
 
 					if ( input.checked )  {
 						label.classList.remove('active');
@@ -108,7 +109,7 @@
 					triggerChange(self.btn) //trigger the change for the btn-group
 				}
 
-				if ( input && input.type === 'radio' ){ // radio buttons
+				if ( input.type === 'radio' ){ // radio buttons
 
 					if ( !input.checked ) { // don't trigger if already active
 						label.classList.add('active');

--- a/lib/button-native.js
+++ b/lib/button-native.js
@@ -75,7 +75,9 @@
 			},
 
 			this.toggle = function(e) {
-				var label = e.target.tagName === 'INPUT' ? e.target.parentNode : e.target; // the .btn label
+				var parent = e.target.parentNode;
+				var label = e.target.tagName === 'LABEL' ? e.target : parent.tagName === 'LABEL' ? parent : null; // the .btn label
+				if ( !label ) return; //react if a label or its immediate child is clicked
 				var target = e.currentTarget || e.srcElement; // the button group, the target of the Button function
 				var labels = target.querySelectorAll('.btn'); // all the button group buttons
 				var input = label.getElementsByTagName('INPUT')[0];


### PR DESCRIPTION
Hello, 

Currently, the script doesn't allow placing other elements inside `<label>` element of a `.btn-group`. That is, for example, we can't use glyphicon as a label for a button inside a button groups like this:

```    
<div class="btn-group " data-toggle="buttons">
        <label class="btn btn-default btn-sm active">
            <input type="checkbox" checked="checked">
            <span class="glyphicon glyphicon-repeat"></span>
        </label>
</div>
```
when the span element receives a click event, the function incorrectly decides that the label is the span element itself leading to an error further on. 

This change would allow to correctly respond to an event on any direct child of a label, thus, allowing to use the said glyphicons as labels, which seems to be a popular thing. 