### PR TITLE
enable custom builds with ignored components

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -10,10 +10,39 @@ var concat = require('gulp-concat');
 var distName = "bootstrap-native";
 var distDir = "dist/";
 var minDir = "lib/min/";
+var srcDir = 'lib/'
 
 gulp.task('default', function() {
-    // Minify the library files only...
-    gulp.src('lib/*.js')
+    // array of source files to build
+    var sources = [
+      srcDir + 'affix-native.js',
+      srcDir + 'alert-native.js',
+      srcDir + 'button-native.js',
+      srcDir + 'carousel-native.js',
+      srcDir + 'collapse-native.js',
+      srcDir + 'dropdown-native.js',
+      srcDir + 'modal-native.js',
+      srcDir + 'popover-native.js',
+      srcDir + 'scrollspy-native.js',
+      srcDir + 'tab-native.js',
+      srcDir + 'tooltip-native.js'
+    ];
+    // simple arg parser to remove sources, expects just the component name
+    // ex: gulp --ignore carousel,scrollspy
+    (function(args){
+      var idx = args.indexOf('--ignore')
+      if (idx<1 || idx == args.length-1) {
+        return;
+      }
+      args[idx+1].split(',').forEach(function(ignore){
+        var didx = sources.indexOf(srcDir + ignore.trim() + '-native.js');
+        if (didx>=0) {
+          sources.splice(didx, 1);
+        }
+      });
+    })(process.argv);
+
+    gulp.src(sources)
     .pipe(uglify())
     .pipe(rename({
         suffix: ".min"
@@ -21,13 +50,13 @@ gulp.task('default', function() {
     .pipe(gulp.dest(minDir));
 
     // Minify everything into a distribution.
-    gulp.src('lib/*.js')
+    gulp.src(sources)
     .pipe(concat(distName+".min.js"))
     .pipe(uglify())
     .pipe(gulp.dest(distDir));
 
     // Just concat
-    gulp.src('lib/*.js')
+    gulp.src(sources)
     .pipe(concat(distName+".js"))
     .pipe(gulp.dest(distDir));
 });

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ So when using `bootstrap.native` inside of a NodeJS app, make sure you create a 
 # Browser Support
 The scripts are developed with clean code mainly for modern browsers that nativelly support HTML5. When using polyfills IE8-IE9 will thank you.
 
+# Custom Builds
+You can clone the repository, install gulp and run `gulp --ignore component,...` ex: `gulp --ignore carousel,scrollspy`
+
 # Contributors
 - [Ingwie Phoenix](https://github.com/IngwiePhoenix): RequireJS/CommonJS compatibility and usability with common package managers. _Was glad to help!_
 - Full contributors list [here](https://github.com/thednp/bootstrap.native/graphs/contributors). Thanks so much!


### PR DESCRIPTION
components can be ignored by passing their names to the --ignore command line argument
ex: `gulp --ignore carousel,scrollspy`