### PR TITLE
Button - Set input checked property

### DIFF
--- a/lib/button-native.js
+++ b/lib/button-native.js
@@ -97,10 +97,12 @@
 						self.addClass(label,'active');
 						input.getAttribute('checked');					
 						input.setAttribute('checked','checked');
+						input.checked = true;
 					} else {
 						self.removeClass(label,'active');
 						input.getAttribute('checked');						
 						input.removeAttribute('checked');
+						input.checked = false;
 					}
 					triggerChange(input); //trigger the change for the input
 					triggerChange(self.btn); //trigger the change for the btn-group


### PR DESCRIPTION
This commit sets the input property checked to true/false when clicked. In some browsers this value is not set correctly due to multiple click events firing even thou the attribute "checked" is set.

In my testing, using both Firefox and Chrome, the Button toggle action callback function is called twice. This has the effect of setting the checkbox attributes and css style correctly but the checked property gets unset, set to false when clicked. This means that when the form is submitted, the traditional way, the value of the checkbox is not sent with the new request.
