### PR TITLE
Button - Set checked to false on other radio buttons in group

### DIFF
--- a/lib/button-native.js
+++ b/lib/button-native.js
@@ -122,7 +122,7 @@
 								var inp = l.getElementsByTagName('INPUT')[0];
 								self.removeClass(l,'active');
 								inp.removeAttribute('checked');
-								input.checked = false;
+								inp.checked = false;
 								triggerChange(inp); // trigger the change								
 							}				
 						}


### PR DESCRIPTION
A small typo has caused radio buttons to all enter a state of not checked.

This patch ensures only the other radio buttons in the button group are set to not checked.