### PR TITLE
Fixes #33

### DIFF
--- a/all.js
+++ b/all.js
@@ -19,7 +19,8 @@
           ```
 */
 
-module.exports = {
+// Collection of all the bootstrap.native modules.
+var bsn = {
     affix:      require("./lib/affix-native"),
     alert:      require("./lib/alert-native"),
     button:     require("./lib/button-native"),
@@ -32,3 +33,33 @@ module.exports = {
     tab:        require("./lib/tab-native"),
     tooltip:    require("./lib/tooltip-native")
 };
+
+/**
+ * Turn the first character into an uppercase character.
+ * 
+ * @param {String} str      Input string
+ * @returns {String}        String with uppercase starting letter.
+ */
+function ucfirst(str) {
+    var cap = str.charAt(0).toUpperCase();
+    return cap+str.substr(1);
+}
+
+/**
+ * This self-executing function takes all the key names from the Bootstrap Native modules
+ * and assigns the original and uppercased key.
+ * 
+ * This allows scripts used to the Uppercase module names to function with CommonJS.
+ * 
+ * @fixes #33
+ * @returns Object
+ */
+module.exports = (function BSNExporter(){
+    var _exports = {};
+    for(var component in bsn) {
+        var key1 = component;
+        var key2 = ucfirst(component);
+        _exports[key1] = _exports[key2] = bsn[component];
+    }
+    return _exports;
+})();


### PR DESCRIPTION
Exporting components with original and lowercased names.

I.e.: `Alert` and `alert`.

```javascript
var bsn = require("bootstrap.native");
assert(bsn.alert === bsn.Alert);
```