### PR TITLE
tab: Fix error when no dropdown is used with tabs

### DIFF
--- a/lib/tab-native.js
+++ b/lib/tab-native.js
@@ -68,10 +68,12 @@
 					self.addClass(next.parentNode,'active');		
 	
 					// handle dropdown menu "active" class name		
-					if ( !(isDropDown.test(self.tab.parentNode.parentNode.className)) ) {
-						if (/active/.test(self.dropdown.className)) self.removeClass(self.dropdown,'active');
-					} else {
-						if (!/active/.test(self.dropdown.className)) self.addClass(self.dropdown,'active');
+					if ( self.dropdown ) {
+						if ( !(isDropDown.test(self.tab.parentNode.parentNode.className)) ) {
+							if (/active/.test(self.dropdown.className)) self.removeClass(self.dropdown,'active');
+						} else {
+							if (!/active/.test(self.dropdown.className)) self.addClass(self.dropdown,'active');
+						}
 					}
 	
 					//1. hide current active content first


### PR DESCRIPTION
If there is no dropdown being used as a tab self.dropdown is null. This
results in an error when attempting to test/set the active class on the null
dropdown variable.

This bug was introduced in commit "Removed `classList` dependency " 7acaaac...