### PR TITLE
Keep preventDefault during Carousel transition.

### DIFF
--- a/lib/carousel-native.js
+++ b/lib/carousel-native.js
@@ -69,6 +69,7 @@
       }
       this.actions();
       this._addEventListeners();
+      this._addPreventDefaultListeners();
     },
     cycle: function(e) {
       var self = this;
@@ -169,6 +170,12 @@
         window.addEventListener('keydown', self.keyHandler, false);
       }
     },
+    _addPreventDefaultListeners : function () {
+      var self = this;
+
+      self.next && self.next.addEventListener( "click", function(e){e.preventDefault()}, false);
+      self.prev && self.prev.addEventListener( "click", function(e){e.preventDefault()}, false);
+    },
     _removeEventListeners : function () { // prevent mouse bubbles while animating
       var self = this;
 
@@ -223,7 +230,6 @@
 
       self.controlsHandler = function (e) {
         var target = e.currentTarget || e.srcElement;
-        e.preventDefault();
 
         if ( target === self.next ) {
           self.index++;


### PR DESCRIPTION
Clicking prev / next during a slide transition appends the carousel tag to the URL as there's no event handlers to call e.preventDefault().
Possibly jarring to user experience as the carousel jumps to page top.