### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ bower install --save bootstrap.native
 
 ```html
 <!-- Using one of the CDN repositories-->
-<script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap.native/2.0.13/bootstrap-native.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/bootstrap.native@2.0.14/dist/bootstrap-native.min.js"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/bootstrap.native/2.0.13/bootstrap-native.min.js"></script>
 <!-- Using a local assets folder -->
 <script type="text/javascript" src="/assets/js/bootstrap-native.min.js"></script>
@@ -35,7 +35,7 @@ $ bower install --save bootstrap.native
 
 ```html
 <!-- Using one of the CDN repositories-->
-<script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap.native/2.0.13/bootstrap-native-v4.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/bootstrap.native@2.0.14/dist/bootstrap-native-v4.js"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/bootstrap.native/2.0.13/bootstrap-native-v4.min.js"></script>
 <!-- Using a local assets folder -->
 <script type="text/javascript" src="/assets/js/bootstrap-native-v4.min.js"></script>
@@ -72,7 +72,7 @@ The components are developed with clean code mainly for modern browsers that nat
 
 ```html
 <!-- Using one of the CDN repositories-->
-<script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap.native/2.0.13/polyfill.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/bootstrap.native@2.0.14/dist/polyfill.min.js"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/bootstrap.native/2.0.13/polyfill.min.js"></script>
 <!-- Using a local assets folder -->
 <script type="text/javascript" src="/assets/js/polyfill.min.js"></script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/bootstrap.native.

Feel free to ping me if you have any questions regarding this change.