### PR TITLE
Don't execute 'show()' when clicking on the active tab.

### DIFF
--- a/lib/V4/tab-native.js
+++ b/lib/V4/tab-native.js
@@ -103,7 +103,7 @@ var Tab = function( element, options ) {
       e[preventDefault]();
       next = e[target][getAttribute](dataToggle) === component || (href && href.charAt(0) === '#')
            ? e[target] : e[target][parentNode]; // allow for child elements like icons to use the handler
-      !tabs[isAnimating] && !hasClass(next[parentNode],active) && self.show();
+      !tabs[isAnimating] && !hasClass(next,active) && self.show();
     };
 
   // public method


### PR DESCRIPTION
Resolving issue #187 