### PR TITLE
Add option to not include the Data API initialization code

### DIFF
--- a/build-module-v4.js
+++ b/build-module-v4.js
@@ -86,7 +86,7 @@ module.exports = (options) => {
 
   function wrap(main) {
     var utils = fs.readFileSync(`${libPath}/V4/utils.js`, 'utf8').split('\n').join('\n  ');
-    var init = options.noInitDataAPI ? '' : fs.readFileSync(`${libPath}/V4/utils-init.js`, 'utf8').split('\n').join('\n  ');
+    var init = options.autoInitDataAPI === false ? '' : options.noInitDataAPI ? '' : fs.readFileSync(`${libPath}/V4/utils-init.js`, 'utf8').split('\n').join('\n  ');
     main = main.split('\n').join('\n  ');
     // Initialize arrays:
     // Arrays will be used in the template literal below

--- a/build-module-v4.js
+++ b/build-module-v4.js
@@ -86,7 +86,7 @@ module.exports = (options) => {
 
   function wrap(main) {
     var utils = fs.readFileSync(`${libPath}/V4/utils.js`, 'utf8').split('\n').join('\n  ');
-    var init = fs.readFileSync(`${libPath}/V4/utils-init.js`, 'utf8').split('\n').join('\n  ');
+    var init = options.noInitDataAPI ? '' : fs.readFileSync(`${libPath}/V4/utils-init.js`, 'utf8').split('\n').join('\n  ');
     main = main.split('\n').join('\n  ');
     // Initialize arrays:
     // Arrays will be used in the template literal below

--- a/build-module.js
+++ b/build-module.js
@@ -86,7 +86,7 @@ module.exports = (options) => {
 
   function wrap(main) {
     var utils = fs.readFileSync(`${libPath}/V3/utils.js`, 'utf8').split('\n').join('\n  ');
-    var init = fs.readFileSync(`${libPath}/V3/utils-init.js`, 'utf8').split('\n').join('\n  ');
+    var init = options.autoInitDataAPI === false ? '' : fs.readFileSync(`${libPath}/V3/utils-init.js`, 'utf8').split('\n').join('\n  ');
     main = main.split('\n').join('\n  ');
     // Initialize arrays:
     // Arrays will be used in the template literal below


### PR DESCRIPTION
We use bootstrap native to build a component. This component can be used on our clients' websites by including our javascript file. As soon as they include our library, bootstrap-native will start searching the entire DOM tree to find data- elements and start initializing them. This will have unintended side-effects. We only want to initialize our own inserted DOM elements programmatically, so I added an option to exclude the utils-init.js code. 
This solved #180 