### PR TITLE
Fix clicks on child elements of a tab

### DIFF
--- a/lib/V4/tab-native.js
+++ b/lib/V4/tab-native.js
@@ -99,10 +99,9 @@ var Tab = function( element, options ) {
     },
     // handler 
     clickHandler = function(e) {
-      var href = e[target][getAttribute]('href');
+      var href = e[currentTarget][getAttribute]('href');
       e[preventDefault]();
-      next = e[target][getAttribute](dataToggle) === component || (href && href.charAt(0) === '#')
-           ? e[target] : e[target][parentNode]; // allow for child elements like icons to use the handler
+      next = e[currentTarget];
       !tabs[isAnimating] && !hasClass(next,active) && self.show();
     };
 

--- a/lib/V4/utils.js
+++ b/lib/V4/utils.js
@@ -50,7 +50,7 @@ var globalObject = typeof global !== 'undefined' ? global : this||window,
 
   // option keys
   backdrop = 'backdrop', keyboard = 'keyboard', delay = 'delay',
-  content = 'content', target = 'target',
+  content = 'content', target = 'target', currentTarget = 'currentTarget',
   interval = 'interval', pause = 'pause', animation = 'animation',
   placement = 'placement', container = 'container',
 


### PR DESCRIPTION
I am using a bootstrap theme which has a slightly complex heirarchy of elements inside a tab:

```html
<div class="card active show" data-toggle="tab" href="#content-1" role="tab">
  <div class="card-body">
    <h5>headline</h5>
    <p>Some more details</p>
  </div>
</div>
```

A click on any element inside the `div.card-body` doesn't work. This PR fixes that by using `event.currentTarget` instead of `event.target`.

Hope I have not broken any existing use case! If so, will be happy to fix it.