### PR TITLE
Resolve error thrown in Dropdown dismissHandler, issue 278

### DIFF
--- a/lib/V4/dropdown-native.js
+++ b/lib/V4/dropdown-native.js
@@ -43,7 +43,9 @@ var Dropdown = function( element, option ) {
 
     // handlers
     dismissHandler = function(e) {
-      var eventTarget = e[target], hasData = eventTarget && (stringDropdown in eventTarget || stringDropdown in eventTarget[parentNode]);
+      var eventTarget = e[target], hasData = eventTarget && (eventTarget[getAttribute](dataToggle) 
+                            || eventTarget[parentNode] && getAttribute in eventTarget[parentNode] 
+                            && eventTarget[parentNode][getAttribute](dataToggle));
       if ( (eventTarget === menu || menu[contains](eventTarget)) && (self.persist || hasData) ) { return; }
       else {
         relatedTarget = eventTarget === element || element[contains](eventTarget) ? element : null;


### PR DESCRIPTION
Fix for [issue 278](https://github.com/thednp/bootstrap.native/issues/278)

When the Dropdown dismissHandler is called, it is possible for `eventTarget[parentNode]` to evaluate to null, causing the following error when using v2.0.26 of the library on safari and chrome *(desktop and mobile)*. Reverting this portion of the code to what was previously used in v2.0.19 resolves this issue.