### PR TITLE
Default Popover trigger to click event

### DIFF
--- a/lib/V4/popover-native.js
+++ b/lib/V4/popover-native.js
@@ -44,7 +44,7 @@ var Popover = function( element, options ) {
 
   // set instance options
   this[template] = options[template] ? options[template] : null; // JavaScript only
-  this[trigger] = options[trigger] ? options[trigger] : triggerData || hoverEvent;
+  this[trigger] = options[trigger] ? options[trigger] : triggerData || clickEvent;
   this[animation] = options[animation] && options[animation] !== fade ? options[animation] : animationData || fade;
   this[placement] = options[placement] ? options[placement] : placementData || top;
   this[delay] = parseInt(options[delay] || delayData) || 200;


### PR DESCRIPTION
This changes the default Popover trigger to `click` event to matches Bootstrap 4 default shown here:
https://getbootstrap.com/docs/4.3/components/popovers/#options

Fixes #298 