### PR TITLE
Dropdown on non-empty anchors

### DIFF
--- a/lib/V3/dropdown-native.js
+++ b/lib/V3/dropdown-native.js
@@ -5,7 +5,7 @@
 // DROPDOWN DEFINITION
 // ===================
 var Dropdown = function( element, option ) {
-    
+
   // initialization element
   element = queryElement(element);
 
@@ -13,10 +13,10 @@ var Dropdown = function( element, option ) {
   this.persist = option === true || element[getAttribute]('data-persist') === 'true' || false;
 
   // constants, event targets, strings
-  var self = this, 
+  var self = this,
     parent = element[parentNode],
     relatedTarget = null,
-    
+
     // strings
     children = 'children',
     component = 'dropdown', open = 'open',
@@ -28,21 +28,21 @@ var Dropdown = function( element, option ) {
     menuItems = (function(){
       var set = menu[children], newSet = [];
       for ( var i=0; i<set[length]; i++ ){
-        set[i][children][length] && (set[i][children][0].tagName === 'A' && newSet[push](set[i]));          
+        set[i][children][length] && (set[i][children][0].tagName === 'A' && newSet[push](set[i]));
       }
       return newSet;
     })(),
 
     // preventDefault on empty anchor links
     preventEmptyAnchor = function(anchor){
-      (anchor.href && anchor.href.slice(-1) === '#' || anchor[parentNode] && anchor[parentNode].href 
-        && anchor[parentNode].href.slice(-1) === '#') && this[preventDefault]();      
+      (anchor.href && anchor.href.slice(-1) === '#' || anchor[parentNode] && anchor[parentNode].href
+        && anchor[parentNode].href.slice(-1) === '#') && this[preventDefault]();
     },
 
     // toggle dismissible events
     toggleDismiss = function(){
       var type = element[open] ? on : off;
-      type(DOC, clickEvent, dismissHandler); 
+      type(DOC, clickEvent, dismissHandler);
       type(DOC, keydownEvent, preventScroll);
       type(DOC, keyupEvent, keyHandler);
       type(DOC, focusEvent, dismissHandler, true);
@@ -50,8 +50,8 @@ var Dropdown = function( element, option ) {
 
     // handlers
     dismissHandler = function(e) {
-      var eventTarget = e[target], hasData = eventTarget && (eventTarget[getAttribute](dataToggle) 
-                            || eventTarget[parentNode] && getAttribute in eventTarget[parentNode] 
+      var eventTarget = e[target], hasData = eventTarget && (eventTarget[getAttribute](dataToggle)
+                            || eventTarget[parentNode] && getAttribute in eventTarget[parentNode]
                             && eventTarget[parentNode][getAttribute](dataToggle));
       if ( e.type === focusEvent && (eventTarget === element || eventTarget === menu || menu[contains](eventTarget) ) ) {
         return;
@@ -67,22 +67,31 @@ var Dropdown = function( element, option ) {
       relatedTarget = element;
       show();
       preventEmptyAnchor.call(e,e[target]);
+       // allow a dropdown menu for anchor elements which have a proper link
+      // only every second click will follow that link
+      if(element.href && element.nextElementSibling == menu) {
+        var dropDownOpen = ((element.getAttribute("data-dropdown-open") || 0) + 1) % 2;
+        element.setAttribute("data-dropdown-open", dropDownOpen);
+        if(dropDownOpen === 1) {
+          e[preventDefault]();
+        }
+      }
     },
     preventScroll = function(e){
       var key = e.which || e.keyCode;
       if( key === 38 || key === 40 ) { e[preventDefault](); }
     },
     keyHandler = function(e){
-      var key = e.which || e.keyCode, 
+      var key = e.which || e.keyCode,
           activeItem = DOC.activeElement,
           idx = menuItems[indexOf](activeItem[parentNode]),
           isSameElement = activeItem === element,
           isInsideMenu = menu[contains](activeItem),
           isMenuItem = activeItem[parentNode][parentNode] === menu;
-      
+
       if ( isMenuItem ) { // navigate up | down
-        idx = isSameElement ? 0 
-                            : key === 38 ? (idx>1?idx-1:0) 
+        idx = isSameElement ? 0
+                            : key === 38 ? (idx>1?idx-1:0)
                             : key === 40 ? (idx<menuItems[length]-1?idx+1:idx) : idx;
         menuItems[idx] && setFocus(menuItems[idx][children][0]);
       }
@@ -94,7 +103,7 @@ var Dropdown = function( element, option ) {
         self.toggle();
         relatedTarget = null;
       }
-    },  
+    },
 
     // private methods
     show = function() {
@@ -107,9 +116,9 @@ var Dropdown = function( element, option ) {
 
       element[open] = true;
       off(element, clickEvent, clickHandler);
-      setTimeout(function(){ 
+      setTimeout(function(){
         setFocus( menu[getElementsByTagName]('INPUT')[0] || element ); // focus the first input item | element
-        toggleDismiss(); 
+        toggleDismiss();
         shownCustomEvent = bootstrapCustomEvent( shownEvent, component, relatedTarget);
         dispatchCustomEvent.call(parent, shownCustomEvent);
         // if ( shownCustomEvent[defaultPrevented] ) return; // TO BE DECIDED
@@ -122,7 +131,7 @@ var Dropdown = function( element, option ) {
 
       removeClass(parent,open);
       element[setAttribute](ariaExpanded,false);
-      
+
       element[open] = false;
       toggleDismiss();
       setFocus(element);
@@ -138,7 +147,7 @@ var Dropdown = function( element, option ) {
 
   // public methods
   this.toggle = function() {
-    if (hasClass(parent,open) && element[open]) { hide(); } 
+    if (hasClass(parent,open) && element[open]) { hide(); }
     else { show(); }
   };
 

--- a/lib/V4/dropdown-native.js
+++ b/lib/V4/dropdown-native.js
@@ -74,7 +74,7 @@ var Dropdown = function( element, option ) {
         var dropDownOpen = ((element.getAttribute("data-dropdown-open") || 0) + 1) % 2;
         element.setAttribute("data-dropdown-open", dropDownOpen);
         if(dropDownOpen === 1) {
-          e.preventDefault();
+          e[preventDefault]();
         }
       }
     },

--- a/lib/V4/dropdown-native.js
+++ b/lib/V4/dropdown-native.js
@@ -5,7 +5,7 @@
 // DROPDOWN DEFINITION
 // ===================
 var Dropdown = function( element, option ) {
-    
+
   // initialization element
   element = queryElement(element);
 
@@ -23,7 +23,7 @@ var Dropdown = function( element, option ) {
 
     // custom events
     showCustomEvent, shownCustomEvent, hideCustomEvent, hiddenCustomEvent,
-    
+
     menu = queryElement('.dropdown-menu', parent),
     menuItems = (function(){
       var set = menu[children], newSet = [];
@@ -36,14 +36,14 @@ var Dropdown = function( element, option ) {
 
     // preventDefault on empty anchor links
     preventEmptyAnchor = function(anchor){
-      (anchor.href && anchor.href.slice(-1) === '#' || anchor[parentNode] && anchor[parentNode].href 
-        && anchor[parentNode].href.slice(-1) === '#') && this[preventDefault]();    
+      (anchor.href && anchor.href.slice(-1) === '#' || anchor[parentNode] && anchor[parentNode].href
+        && anchor[parentNode].href.slice(-1) === '#') && this[preventDefault]();
     },
 
     // toggle dismissible events
     toggleDismiss = function(){
       var type = element[open] ? on : off;
-      type(DOC, clickEvent, dismissHandler); 
+      type(DOC, clickEvent, dismissHandler);
       type(DOC, keydownEvent, preventScroll);
       type(DOC, keyupEvent, keyHandler);
       type(DOC, focusEvent, dismissHandler, true);
@@ -51,8 +51,8 @@ var Dropdown = function( element, option ) {
 
     // handlers
     dismissHandler = function(e) {
-      var eventTarget = e[target], hasData = eventTarget && (eventTarget[getAttribute](dataToggle) 
-                            || eventTarget[parentNode] && getAttribute in eventTarget[parentNode] 
+      var eventTarget = e[target], hasData = eventTarget && (eventTarget[getAttribute](dataToggle)
+                            || eventTarget[parentNode] && getAttribute in eventTarget[parentNode]
                             && eventTarget[parentNode][getAttribute](dataToggle));
       if ( e.type === focusEvent && (eventTarget === element || eventTarget === menu || menu[contains](eventTarget) ) ) {
         return;
@@ -68,6 +68,15 @@ var Dropdown = function( element, option ) {
       relatedTarget = element;
       show();
       preventEmptyAnchor.call(e,e[target]);
+      // allow a dropdown menu for anchor elements which have a proper link
+      // only every second click will follow that link
+      if(element.href && element.nextElementSibling == menu) {
+        var dropDownOpen = ((element.getAttribute("data-dropdown-open") || 0) + 1) % 2;
+        element.setAttribute("data-dropdown-open", dropDownOpen);
+        if(dropDownOpen === 1) {
+          e.preventDefault();
+        }
+      }
     },
     preventScroll = function(e){
       var key = e.which || e.keyCode;
@@ -79,10 +88,10 @@ var Dropdown = function( element, option ) {
         idx = menuItems[indexOf](activeItem),
         isSameElement = activeItem === element,
         isInsideMenu = menu[contains](activeItem),
-        isMenuItem = activeItem[parentNode] === menu || activeItem[parentNode][parentNode] === menu;          
+        isMenuItem = activeItem[parentNode] === menu || activeItem[parentNode][parentNode] === menu;
 
       if ( isMenuItem ) { // navigate up | down
-        idx = isSameElement ? 0 
+        idx = isSameElement ? 0
                             : key === 38 ? (idx>1?idx-1:0)
                             : key === 40 ? (idx<menuItems[length]-1?idx+1:idx) : idx;
         menuItems[idx] && setFocus(menuItems[idx]);
@@ -112,7 +121,7 @@ var Dropdown = function( element, option ) {
         setFocus( menu[getElementsByTagName]('INPUT')[0] || element ); // focus the first input item | element
         toggleDismiss();
         shownCustomEvent = bootstrapCustomEvent( shownEvent, component, relatedTarget);
-        dispatchCustomEvent.call(parent, shownCustomEvent);        
+        dispatchCustomEvent.call(parent, shownCustomEvent);
       },1);
     },
     hide = function() {
@@ -137,7 +146,7 @@ var Dropdown = function( element, option ) {
 
   // public methods
   this.toggle = function() {
-    if (hasClass(parent,showClass) && element[open]) { hide(); } 
+    if (hasClass(parent,showClass) && element[open]) { hide(); }
     else { show(); }
   };
 


### PR DESCRIPTION
The jQuery Bootstrap implementation allows dropdown menus on non-empty anchors. My changes to the code make sure that the actual link is only followed on every second click. The first click will open the dropdown.