### PR TITLE
Fix alert close, closed event

### DIFF
--- a/lib/V4/alert-native.js
+++ b/lib/V4/alert-native.js
@@ -12,8 +12,8 @@ var Alert = function( element ) {
   // bind, target alert, duration and stuff
   var self = this, component = 'alert',
     // custom events
-    closeCustomEvent = bootstrapCustomEvent(closedEvent, component),
-    closedCustomEvent = bootstrapCustomEvent(closeEvent, component),
+    closeCustomEvent = bootstrapCustomEvent(closeEvent, component),
+    closedCustomEvent = bootstrapCustomEvent(closedEvent, component),
     alert = getClosest(element,'.'+component),
     triggerHandler = function(){ hasClass(alert,'fade') ? emulateTransitionEnd(alert,transitionEndHandler) : transitionEndHandler(); },
     // handlers


### PR DESCRIPTION
I don't quite understand why `closeEvent` and `closedEvent` are swapped here. Is there any special reason?
It is a little unexpected that `closed.bs.alert` was dispatched prior to `close.bs.alert`.