### PR TITLE
Fix modal hide race condition

### DIFF
--- a/lib/V4/modal-native.js
+++ b/lib/V4/modal-native.js
@@ -224,15 +224,10 @@ var Modal = function(element, options) { // element can be the modal/triggering 
       if ( hideCustomEvent[defaultPrevented] ) return;
 
       modal[isAnimating] = true;    
-      overlay = queryElement('.'+modalBackdropString);
-      overlayDelay = overlay && getTransitionDurationFromElement(overlay);
-
       removeClass(modal,showClass);
       modal[setAttribute](ariaHidden, true);
 
-      setTimeout(function(){
-        hasClass(modal,'fade') ? emulateTransitionEnd(modal, triggerHide) : triggerHide();
-      }, supportTransitions && overlay && overlayDelay ? overlayDelay : 2);
+      hasClass(modal,'fade') ? emulateTransitionEnd(modal, triggerHide) : triggerHide();
     },2)
   };
   this.setContent = function( content ) {

--- a/lib/V4/modal-native.js
+++ b/lib/V4/modal-native.js
@@ -129,6 +129,8 @@ var Modal = function(element, options) { // element can be the modal/triggering 
           off(globalObject, resizeEvent, self.update, passiveHandler);
           off(modal, clickEvent, dismissHandler);
           off(DOC, keydownEvent, keyHandler);
+        } else {
+          overlay = null;
         }
       }());
       modal[isAnimating] = false;


### PR DESCRIPTION
Overlay would be handled in `triggerHide`, the timeout here have no effect other than delay `transitionend` event listener to be added.
When modal was used with `fade`, with a default bootstrap css, the `overlayDelay` would be the same as modal's, resulting a race between the call of `emulateTransitionEnd` and the `transitionend` event. In most cases, the event listener would be added prior to the event but not guaranteed. By a tiny chance the `transitionend` event would be dispatched prior to listener added, then the page would get stuck at the overlay without the modal. `hidden.bs.modal` would not be dispatched either.