### PR TITLE
A simple fix for bootstrap native equivalent of twbs #22049 and #21079

### DIFF
--- a/src/components/collapse-native.js
+++ b/src/components/collapse-native.js
@@ -73,7 +73,7 @@ export default function Collapse(element,options) {
 
   // public methods
   self.toggle = e => {
-    e && e.preventDefault();
+    if (e && e.target.tagName === 'A') {e.preventDefault();}
     if (!hasClass(collapse,'show')) { self.show(); } 
     else { self.hide(); }
   }


### PR DESCRIPTION
As this fix is simple, short and easy on resources, i open a pull request for it.
Using this fix, inputs used for toggling collapses will still receive the click event so they can change state if needed. This fix uses the same method as the actual solution employed by twbs: it only `preventDefault()` for `<a>` tags, which may change the URL.
This way bootstrap native behavior will become a bit closer to twbs 4.