### PR TITLE
Demo: Fix invalid anchor navigation on OS X platform

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -4,7 +4,7 @@ var offCanvasCollapse = document.getElementsByClassName('offcanvas-collapse')[0]
 		sideNav = document.getElementById('side-nav'),
 		topNav = document.getElementById('top-nav'),
 		sideLinks = Array.from(sideNav.getElementsByTagName("A")).concat(Array.from(topNav.getElementsByTagName("A"))),
-		scrollTarget = /(EDGE|Mac)/i.test(navigator.userAgent) ? document.body : document.documentElement;
+		scrollTarget = /(EDGE)/i.test(navigator.userAgent) ? document.body : document.documentElement;
 
 sideLinks.map((x,i) => x.addEventListener('click', (e) => { 
 	var target = document.getElementById(x.getAttribute('href').replace('#', ''));


### PR DESCRIPTION
Hi, on [Demo page](http://thednp.github.io/bootstrap.native/) is not working anchor navigation in side-menu on OS X (MacBook and another Apple devices). It because native scrolling mechanism is disabled by script and that is failure.

Main problem I see in this line of code:
https://github.com/thednp/bootstrap.native/blob/c34625a779abcd90431019312f0dfd3908de5535/assets/js/scripts.js#L7

Here is for unknown reason tested `Mac` substring in User-Agent to switch to legacy fallback in conformity with IE, EDGE and similar _sh*t_ browsers. But that `Mac` is conflicted with User-Agent on all browsers on OS X platform:

```
Chrome:  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36
                      ^^^^^^^^^
Safari:  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15
                      ^^^^^^^^^
Firefox: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:80.0) Gecko/20100101 Firefox/80.0
                      ^^^^^^^^^
```

This PR removes `Mac` substring from fallback trigger, because I don't know the reason why is here. If is here for good reason, please change my suggest to prevent false-positive match with `Macintosh` UA.