### PR TITLE
Fixed wrong default value of Tab.options.height in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2683,7 +2683,7 @@ myScrollSpyInit.dispose();
                     <tr>
                       <td><code>height</code></td>
                       <td><em>boolean</em></td>
-                      <td><em>false</em></td>
+                      <td><em>true</em></td>
                       <td>Option to enable animation of the height of the <code>.tab-content</code> tabs container. Can be set via
                         JavaScript or the <code>data-height="true"</code> attribute.</td>
                     </tr>


### PR DESCRIPTION
Hi,
I was working on Typescript definition for this awesome projects of yours and I noticed slight inconsistency between docs and code.

In docs, default value for `height` in Tab options is `false`, but if I read the code correctly it's treated as `true` unless `false` is explicitly passed.
https://github.com/thednp/bootstrap.native/blob/0bb6028767728c76a5c5d3f0edb00b03d5398cc1/src/components/tab-native.js#L174