### PR TITLE
Removed duplicate method Tooltip.hide() from docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3193,9 +3193,6 @@ myToastInit.dispose();
                 <dt class="col-md-2">.hide()</dt>
                 <dd class="col-md-10">The method hides an initialized tooltip and remove it from it's container and
                   also from the memory, as if you would automatically <em>destroy</em> it.</dd>
-                <dt class="col-md-2">.hide()</dt>
-                <dd class="col-md-10">The method hides an initialized tooltip and remove it from it's container and
-                  also from the memory, as if you would automatically <em>destroy</em> it.</dd>
                 <dt class="col-md-2">.toggle()</dt>
                 <dd class="col-md-10">The method shows the tooltip if hidden and hides it otherwise, using the above
                   two methods.</dd>


### PR DESCRIPTION
Hi,
while browsing docs I noticed that `Tooltip.hide()` method is mentioned twice.

![image](https://user-images.githubusercontent.com/5658260/95240969-6e1e2b00-080d-11eb-8293-114063322df5.png)
