### PR TITLE
Add Tab.dispose() to docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2705,6 +2705,8 @@ myScrollSpyInit.dispose();
                 <dd class="col-md-10">The public method to switch to a certain tab of your choice via JavaScript. If that tab is already 
                   visible / active or the method is called while animation is running, the call has no effect.</dd>
               </dl>
+              <dt class="col-md-2">.dispose()</dt>
+              <dd class="col-md-10">Removes the component from the target element.</dd>
             </section>
           
             <section id="tabEvents">


### PR DESCRIPTION
In code of `tab-native.js`, there is public method `dispose()`. This method is also on every other component yet it's not mentioned in docs right now.

https://github.com/thednp/bootstrap.native/blob/0bb6028767728c76a5c5d3f0edb00b03d5398cc1/src/components/tab-native.js#L155