### PR TITLE
Added type definitions for Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.13",
   "description": "Native JavaScript for Bootstrap, the sweetest JavaScript library without jQuery.",
   "main": "dist/bootstrap-native.min.js",
+  "types": "src/index.d.ts",
   "module": "dist/bootstrap-native.esm.js",
   "jsnext": "src/index.js",
   "files": [

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,275 @@
+type SelectorOrReference = string | Element;
+type Placement = "top" | "bottom" | "left" | "right";
+
+declare module "bootstrap.native/dist/components/alert-native.esm.js" {
+    export default class Alert {
+        constructor(element: SelectorOrReference)
+
+        close(): void;
+
+        dispose(): void;
+    }
+}
+
+declare module "bootstrap.native/dist/components/button-native.esm.js" {
+    export default class Button {
+        constructor(element: SelectorOrReference);
+
+        dispose(): void;
+    }
+}
+
+declare module "bootstrap.native/dist/components/carousel-native.esm.js" {
+    export default class Carousel {
+        constructor(element: SelectorOrReference, options?: CarouselOptions);
+
+        cycle(): void;
+
+        slideTo(index: number): void;
+
+        getActiveIndex(): number;
+
+        dispose(): void;
+    }
+
+    export interface CarouselOptions {
+        /** @default true */
+        keyboard?: boolean;
+
+        /** @default hover */
+        pause?: boolean | "hover";
+
+        /** @default true */
+        touch?: boolean;
+
+        /** @default 5000 */
+        interval?: number;
+    }
+}
+
+declare module "bootstrap.native/dist/components/collapse-native.esm.js" {
+    export default class Collapse {
+        constructor(element: SelectorOrReference, options?: CollapseOptions);
+
+        show(): void;
+
+        hide(): void;
+
+        toggle(): void;
+
+        dispose(): void;
+    }
+
+    export interface CollapseOptions {
+        parent?: SelectorOrReference;
+        target?: SelectorOrReference;
+    }
+}
+
+declare module "bootstrap.native/dist/components/dropdown-native.esm.js" {
+    export default class Dropdown {
+        constructor(element: SelectorOrReference, persist?: boolean);
+
+        toggle(): void;
+
+        dispose(): void;
+    }
+}
+
+declare module "bootstrap.native/dist/components/modal-native.esm.js" {
+    export default class Modal {
+        constructor(element: SelectorOrReference, options?: ModalOptions);
+
+        show(): void;
+
+        hide(): void;
+
+        toggle(): void;
+
+        setContent(content: string): void;
+
+        update(): void;
+
+        dispose(): void;
+    }
+
+    export interface ModalOptions {
+        /** @default true */
+        backdrop?: boolean | "static";
+
+        /** @default true */
+        keyboard?: boolean;
+
+        content?: string;
+    }
+}
+
+declare module "bootstrap.native/dist/components/popover-native.esm.js" {
+    export default class Popover {
+        constructor(element: SelectorOrReference, options?: PopoverOptions);
+
+        show(): void;
+
+        hide(): void;
+
+        toggle(): void;
+
+        dispose(): void;
+    }
+
+    export interface PopoverOptions {
+        template?: string;
+
+        content?: string;
+
+        title?: string;
+
+        /** @default false */
+        dismissible?: boolean;
+
+        /** @default hover */
+        trigger?: string;
+
+        /** @default fade */
+        animation?: string;
+
+        /** @default top */
+        placement?: Placement;
+
+        /** @default 200 */
+        delay?: number;
+
+        /** @default body */
+        container?: SelectorOrReference;
+    }
+}
+
+declare module "bootstrap.native/dist/components/scrollspy-native.esm.js" {
+    export default class ScrollSpy {
+        constructor(element: SelectorOrReference, options?: ScrollSpyOptions);
+
+        show(): void;
+
+        dispose(): void;
+    }
+
+    export interface ScrollSpyOptions {
+        target?: SelectorOrReference;
+
+        /** @default 10 */
+        offset: number;
+    }
+}
+
+declare module "bootstrap.native/dist/components/tab-native.esm.js" {
+    export default class Tab {
+        constructor(element: SelectorOrReference, options?: TabOptions);
+
+        refresh(): void;
+
+        dispose(): void;
+    }
+
+    export interface TabOptions {
+        /** @default true */
+        height?: boolean;
+    }
+}
+
+declare module "bootstrap.native/dist/components/toast-native.esm.js" {
+    export default class Toast {
+        constructor(element: SelectorOrReference, options?: ToastOptions);
+
+        show(): void;
+
+        hide(): void;
+
+        dispose(): void;
+    }
+
+    export interface ToastOptions {
+        /** @default true */
+        animation?: boolean;
+
+        /** @default true */
+        autohide?: boolean;
+
+        /** @default 500 */
+        delay?: number;
+    }
+}
+
+declare module "bootstrap.native/dist/components/tooltip-native.esm.js" {
+    export default class Tooltip {
+        constructor(element: SelectorOrReference, options?: TooltipOptions);
+
+        show(): void;
+
+        hide(): void;
+
+        toggle(): void;
+
+        dispose(): void;
+    }
+
+    export interface TooltipOptions {
+        template?: string;
+
+        /** @default true */
+        animation?: boolean;
+
+        /** @default top */
+        placement?: Placement;
+
+        /** @default 200 */
+        delay?: number;
+
+        /** @default body */
+        container?: SelectorOrReference;
+    }
+}
+
+declare module "bootstrap.native" {
+    import Alert from "bootstrap.native/dist/components/alert-native.esm.js";
+    import Button from "bootstrap.native/dist/components/button-native.esm.js";
+    import Carousel from "bootstrap.native/dist/components/carousel-native.esm.js";
+    import Collapse from "bootstrap.native/dist/components/collapse-native.esm.js";
+    import Dropdown from "bootstrap.native/dist/components/dropdown-native.esm.js";
+    import Modal from "bootstrap.native/dist/components/modal-native.esm.js";
+    import Popover from "bootstrap.native/dist/components/popover-native.esm.js";
+    import ScrollSpy from "bootstrap.native/dist/components/scrollspy-native.esm.js";
+    import Tab from "bootstrap.native/dist/components/tab-native.esm.js";
+    import Toast from "bootstrap.native/dist/components/toast-native.esm.js";
+
+    interface Components {
+        Alert: typeof Alert;
+        Button: typeof Button;
+        Carousel: typeof Carousel;
+        Collapse: typeof Collapse;
+        Dropdown: typeof Dropdown;
+        Modal: typeof Modal;
+        Popover: typeof Popover;
+        ScrollSpy: typeof ScrollSpy;
+        Tab: typeof Tab;
+        Toast: typeof Toast;
+    }
+
+    interface BSN extends Components {
+        initCallback(
+            /** @default document */
+            element?: Element
+        ): void;
+
+        removeDataAPI(
+            /** @default document */
+            container?: Element
+        ): void;
+
+        Version: string;
+        componentsInit: object;
+    }
+
+    const BSN: BSN;
+
+    export default BSN;
+}


### PR DESCRIPTION
Hi,
first of all thank you for this wonderful project, it really makes my life easier.
In my private projects as well in work projects I make heavy use of bootstrap.native and since we
write all our frontend code in Typescript, we always copy&paste Typescript definitions for bootstrap.native between different
codebases. Since we do this anyway, I polished our type definitions, added some for components we weren't using and decided to make it available.

While browsing the issues I noticed that this was previously brought up in #69, but there was no one willing to submit a PR.

This PR adds typehints for (hopefully) whole public API of this package. What is typed:
- import from `bootstrap.native` -> this will be correctly recognized as object with component constructors and public utility methods.
- imports from `bootstrap.native/dist/components/XXX-native.esm.js` - apart from default export of component itself, there is also named export of interface for component options, so this typechecks as well:

```ts
import Modal, {ModalOptions} from "bootstrap.native/dist/components/modal-native.esm.js";

function createModal(options: ModalOptions) {
    new Modal(document.querySelector('#modal'), options);
}
```

I used both docs and JS code as source.
The type definitions are nearly 1:1 to [docs](https://thednp.github.io/bootstrap.native/) with two differences:
- In definitions I documented default value of `height` option for Tab as `true` (I think it's not documented correctly and I submitted docs fix #388)
- In definitions I added `Tab.dispose()`, which is currently not mentioned in docs (I submitted docs fix #390)

I hope it will be useful. If for any reason your might not want to include the definitions in this package, I would submit it as `@types/bootstrap.native` although it would make things slightly more complicated for end-users.