### PR TITLE
implements Bootstrap-4 style properties for custom events

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,8 +519,17 @@ myRadioButtonGroup.getElementsByTagName('INPUT')[0].addEventListener('change.bs.
           
             <section id="carouselEvents">
               <h3>Carousel Events</h3>
-              <p>All the component's original event are triggered for the <code>&lt;div class="carousel"&gt;</code> element, and the
-                <code>event.relatedTarget</code> is the newly activated carousel item.</p>
+              <p>The carousel component exposes two events that allow you to trigger custom functionality when the carousel slides. All the component's events are triggered on the <code>&lt;div class="carousel"&gt;</code> element. Both events have the following additional properties:</p>
+              <dl class="row">
+                <dt class="col-md-2">direction<dt>
+                <dd class="col-md-10">The direction the carousel is sliding, either <code>left</code> or <code>right</code>.</dd>
+                <dt class="col-md-2">from</dt>
+                <dd class="col-md-10">The index of the current carousel item (integer starting with <code>0</code> index).</dd>
+                <dt class="col-md-2">to</dt>
+                <dd class="col-md-10">The index of the next carousel item.</dd>
+                <dt class="col-md-2">relatedTarget</dt>
+                <dd class="col-md-10">The DOM element of the next carousel item.</dd>
+              </dl>
               <div class="table-responsive">
                 <table class="table table-bordered table-striped bs-events-table">
                   <thead>
@@ -542,6 +551,12 @@ myRadioButtonGroup.getElementsByTagName('INPUT')[0].addEventListener('change.bs.
                   </tbody>
                 </table>
               </div>
+              <p>For example:</p>
+<pre><code class="language-javascript">// this function will run when the carousel begins to slide
+document.querySelector('.carousel').addEventListener('slide.bs.carousel', event => {
+  console.log("The carousel is sliding " + event.direction);
+});
+</code></pre>
             </section>
           
             <section id="carouselDATA">

--- a/src/components/carousel-native.js
+++ b/src/components/carousel-native.js
@@ -197,8 +197,8 @@ export default function Carousel (element,options) {
   self.slideTo = next => {
     if (vars.isSliding) return; // when controled via methods, make sure to check again      
 
-    // the current active and orientation
-    let activeItem = self.getActiveIndex(), orientation;
+    // the current active, orientation, event properties
+    let activeItem = self.getActiveIndex(), orientation, properties;
 
     // first return if we're on the same item #227
     if ( activeItem === next ) {
@@ -216,8 +216,9 @@ export default function Carousel (element,options) {
 
     orientation = vars.direction === 'left' ? 'next' : 'prev'; // determine type
 
-    slideCustomEvent = bootstrapCustomEvent('slide', 'carousel', slides[next]);
-    slidCustomEvent = bootstrapCustomEvent('slid', 'carousel', slides[next]);
+    properties = { relatedTarget: slides[next], direction: vars.direction, from: activeItem, to: next };
+    slideCustomEvent = bootstrapCustomEvent('slide', 'carousel', properties);
+    slidCustomEvent = bootstrapCustomEvent('slid', 'carousel', properties);
     dispatchCustomEvent.call(element, slideCustomEvent); // here we go with the slide
     if (slideCustomEvent.defaultPrevented) return; // discontinue when prevented
 

--- a/src/components/dropdown-native.js
+++ b/src/components/dropdown-native.js
@@ -90,7 +90,7 @@ export default function Dropdown(element,option) {
 
   // public methods
   self.show = () => {
-    showCustomEvent = bootstrapCustomEvent('show', 'dropdown', relatedTarget);
+    showCustomEvent = bootstrapCustomEvent('show', 'dropdown', { relatedTarget: relatedTarget });
     dispatchCustomEvent.call(parent, showCustomEvent);
     if ( showCustomEvent.defaultPrevented ) return;
 
@@ -102,12 +102,12 @@ export default function Dropdown(element,option) {
     setTimeout(() => {
       setFocus( menu.getElementsByTagName('INPUT')[0] || element ); // focus the first input item | element
       toggleDismiss();
-      shownCustomEvent = bootstrapCustomEvent( 'shown', 'dropdown', relatedTarget);
+      shownCustomEvent = bootstrapCustomEvent('shown', 'dropdown', { relatedTarget: relatedTarget });
       dispatchCustomEvent.call(parent, shownCustomEvent);        
     },1);
   }
   self.hide = () => {
-    hideCustomEvent = bootstrapCustomEvent('hide', 'dropdown', relatedTarget);
+    hideCustomEvent = bootstrapCustomEvent('hide', 'dropdown', { relatedTarget: relatedTarget });
     dispatchCustomEvent.call(parent, hideCustomEvent);
     if ( hideCustomEvent.defaultPrevented ) return;
 
@@ -122,7 +122,7 @@ export default function Dropdown(element,option) {
       element.Dropdown && element.addEventListener('click',clickHandler,false); 
     },1);
 
-    hiddenCustomEvent = bootstrapCustomEvent('hidden', 'dropdown', relatedTarget);
+    hiddenCustomEvent = bootstrapCustomEvent('hidden', 'dropdown', { relatedTarget: relatedTarget });
     dispatchCustomEvent.call(parent, hiddenCustomEvent);
   }
   self.toggle = () => {

--- a/src/components/modal-native.js
+++ b/src/components/modal-native.js
@@ -115,7 +115,7 @@ export default function Modal(element,options) { // element can be the modal/tri
 
     toggleEvents(1);
 
-    shownCustomEvent = bootstrapCustomEvent('shown', 'modal', relatedTarget);
+    shownCustomEvent = bootstrapCustomEvent('shown', 'modal', { relatedTarget: relatedTarget });
     dispatchCustomEvent.call(modal, shownCustomEvent);
   }
   function triggerHide(force) {
@@ -181,7 +181,7 @@ export default function Modal(element,options) { // element can be the modal/tri
   self.show = () => {
     if (modal.classList.contains('show') && !!modal.isAnimating ) {return}
 
-    showCustomEvent = bootstrapCustomEvent('show', 'modal', relatedTarget);
+    showCustomEvent = bootstrapCustomEvent('show', 'modal', { relatedTarget: relatedTarget });
     dispatchCustomEvent.call(modal, showCustomEvent);
 
     if ( showCustomEvent.defaultPrevented ) return;

--- a/src/components/scrollspy-native.js
+++ b/src/components/scrollspy-native.js
@@ -77,7 +77,7 @@ export default function ScrollSpy(element,options) {
       if (dropLink && !dropLink.classList.contains('active') ) {
         dropLink.classList.add('active');
       }
-      dispatchCustomEvent.call(element, bootstrapCustomEvent( 'activate', 'scrollspy', vars.items[index]));
+      dispatchCustomEvent.call(element, bootstrapCustomEvent( 'activate', 'scrollspy', { relatedTarget: vars.items[index] }));
     } else if ( isActive && !inside ) {
       item.classList.remove('active');
 

--- a/src/components/tab-native.js
+++ b/src/components/tab-native.js
@@ -61,7 +61,7 @@ export default function Tab(element,options) {
     } else {
       tabs.isAnimating = false; 
     }
-    shownCustomEvent = bootstrapCustomEvent('shown', 'tab', activeTab);
+    shownCustomEvent = bootstrapCustomEvent('shown', 'tab', { relatedTarget: activeTab });
     dispatchCustomEvent.call(next, shownCustomEvent);
   }
   function triggerHide() {
@@ -71,8 +71,8 @@ export default function Tab(element,options) {
       containerHeight = activeContent.scrollHeight;
     }
 
-    showCustomEvent = bootstrapCustomEvent('show', 'tab', activeTab);
-    hiddenCustomEvent = bootstrapCustomEvent('hidden', 'tab', next);
+    showCustomEvent = bootstrapCustomEvent('show', 'tab', { relatedTarget: activeTab });
+    hiddenCustomEvent = bootstrapCustomEvent('hidden', 'tab', { relatedTarget: next });
 
     dispatchCustomEvent.call(next, showCustomEvent);
     if ( showCustomEvent.defaultPrevented ) return;
@@ -127,7 +127,7 @@ export default function Tab(element,options) {
       activeTab = getActiveTab(); 
       activeContent = getActiveContent();
   
-      hideCustomEvent = bootstrapCustomEvent( 'hide', 'tab', next);
+      hideCustomEvent = bootstrapCustomEvent( 'hide', 'tab', { relatedTarget: next });
       dispatchCustomEvent.call(activeTab, hideCustomEvent);
       if (hideCustomEvent.defaultPrevented) return;
   

--- a/src/util/bootstrapCustomEvent.js
+++ b/src/util/bootstrapCustomEvent.js
@@ -1,5 +1,11 @@
-export default function(eventName, componentName, related) {
+export default function(eventName, componentName, properties) {
   let OriginalCustomEvent = new CustomEvent( eventName + '.bs.' + componentName, {cancelable: true});
-  OriginalCustomEvent.relatedTarget = related;
+  if (typeof properties !== 'undefined') {
+    Object.keys(properties).forEach(key => {
+      Object.defineProperty(OriginalCustomEvent, key, {
+        value: properties[key]
+      });
+    });
+  }
   return OriginalCustomEvent;
 }


### PR DESCRIPTION
Refactored util/bootstrapCustomEvent to accept a list of properties to copy onto the event (fully implements Bootstrap 4). Implemented this in carousel (added 'direction', 'from', 'to' properties to event). Tested in Firefox and Chromium. Also updated dropdown, modal, scrollspy, tab components for compatibility but did not add any new functionality to those components nor test them.

Resolves #394 