### PR TITLE
Typescript definitions for ES sources

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -284,6 +284,7 @@ declare module "bootstrap.native" {
     import ScrollSpy from "bootstrap.native/src/components/scrollspy-native.js";
     import Tab from "bootstrap.native/src/components/tab-native.js";
     import Toast from "bootstrap.native/src/components/toast-native.js";
+    import Tooltip from "bootstrap.native/src/components/tooltip-native.js";
 
     interface Components {
         Alert: typeof Alert;
@@ -296,6 +297,7 @@ declare module "bootstrap.native" {
         ScrollSpy: typeof ScrollSpy;
         Tab: typeof Tab;
         Toast: typeof Toast;
+        Tooltip: typeof Tooltip;
     }
 
     interface BSN extends Components {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 type SelectorOrReference = string | Element;
 type Placement = "top" | "bottom" | "left" | "right";
 
-declare module "bootstrap.native/dist/components/alert-native.esm.js" {
+declare module "bootstrap.native/src/components/alert-native.js" {
     export default class Alert {
         constructor(element: SelectorOrReference)
 
@@ -11,7 +11,11 @@ declare module "bootstrap.native/dist/components/alert-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/button-native.esm.js" {
+declare module "bootstrap.native/dist/components/alert-native.esm.js" {
+    export {default} from "bootstrap.native/src/components/alert-native.js"
+}
+
+declare module "bootstrap.native/src/components/button-native.js" {
     export default class Button {
         constructor(element: SelectorOrReference);
 
@@ -19,7 +23,11 @@ declare module "bootstrap.native/dist/components/button-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/carousel-native.esm.js" {
+declare module "bootstrap.native/dist/components/button-native.esm.js" {
+    export {default} from "bootstrap.native/src/components/button-native.js"
+}
+
+declare module "bootstrap.native/src/components/carousel-native.js" {
     export default class Carousel {
         constructor(element: SelectorOrReference, options?: CarouselOptions);
 
@@ -47,7 +55,11 @@ declare module "bootstrap.native/dist/components/carousel-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/collapse-native.esm.js" {
+declare module "bootstrap.native/dist/components/carousel-native.esm.js" {
+    export {default, CarouselOptions} from "bootstrap.native/src/components/carousel-native.js"
+}
+
+declare module "bootstrap.native/src/components/collapse-native.js" {
     export default class Collapse {
         constructor(element: SelectorOrReference, options?: CollapseOptions);
 
@@ -66,7 +78,11 @@ declare module "bootstrap.native/dist/components/collapse-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/dropdown-native.esm.js" {
+declare module "bootstrap.native/dist/components/collapse-native.esm.js" {
+    export {default, CollapseOptions} from "bootstrap.native/src/components/collapse-native.js"
+}
+
+declare module "bootstrap.native/src/components/dropdown-native.js" {
     export default class Dropdown {
         constructor(element: SelectorOrReference, persist?: boolean);
 
@@ -76,7 +92,11 @@ declare module "bootstrap.native/dist/components/dropdown-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/modal-native.esm.js" {
+declare module "bootstrap.native/dist/components/dropdown-native.esm.js" {
+    export {default} from "bootstrap.native/src/components/dropdown-native.js"
+}
+
+declare module "bootstrap.native/src/components/modal-native.js" {
     export default class Modal {
         constructor(element: SelectorOrReference, options?: ModalOptions);
 
@@ -104,7 +124,11 @@ declare module "bootstrap.native/dist/components/modal-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/popover-native.esm.js" {
+declare module "bootstrap.native/dist/components/modal-native.esm.js" {
+    export {default, ModalOptions} from "bootstrap.native/src/components/modal-native.js"
+}
+
+declare module "bootstrap.native/src/components/popover-native.js" {
     export default class Popover {
         constructor(element: SelectorOrReference, options?: PopoverOptions);
 
@@ -144,7 +168,11 @@ declare module "bootstrap.native/dist/components/popover-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/scrollspy-native.esm.js" {
+declare module "bootstrap.native/dist/components/popover-native.esm.js" {
+    export {default, PopoverOptions} from "bootstrap.native/src/components/popover-native.js"
+}
+
+declare module "bootstrap.native/src/components/scrollspy-native.js" {
     export default class ScrollSpy {
         constructor(element: SelectorOrReference, options?: ScrollSpyOptions);
 
@@ -161,7 +189,11 @@ declare module "bootstrap.native/dist/components/scrollspy-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/tab-native.esm.js" {
+declare module "bootstrap.native/dist/components/scrollspy-native.esm.js" {
+    export {default, ScrollSpyOptions} from "bootstrap.native/src/components/scrollspy-native.js"
+}
+
+declare module "bootstrap.native/src/components/tab-native.js" {
     export default class Tab {
         constructor(element: SelectorOrReference, options?: TabOptions);
 
@@ -176,7 +208,11 @@ declare module "bootstrap.native/dist/components/tab-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/toast-native.esm.js" {
+declare module "bootstrap.native/dist/components/tab-native.esm.js" {
+    export {default, TabOptions} from "bootstrap.native/src/components/tab-native.js"
+}
+
+declare module "bootstrap.native/src/components/toast-native.js" {
     export default class Toast {
         constructor(element: SelectorOrReference, options?: ToastOptions);
 
@@ -199,7 +235,11 @@ declare module "bootstrap.native/dist/components/toast-native.esm.js" {
     }
 }
 
-declare module "bootstrap.native/dist/components/tooltip-native.esm.js" {
+declare module "bootstrap.native/dist/components/toast-native.esm.js" {
+    export {default, ToastOptions} from "bootstrap.native/src/components/toast-native.js"
+}
+
+declare module "bootstrap.native/src/components/tooltip-native.js" {
     export default class Tooltip {
         constructor(element: SelectorOrReference, options?: TooltipOptions);
 
@@ -229,17 +269,21 @@ declare module "bootstrap.native/dist/components/tooltip-native.esm.js" {
     }
 }
 
+declare module "bootstrap.native/dist/components/tooltip-native.esm.js" {
+    export {default, TooltipOptions} from "bootstrap.native/src/components/tooltip-native.js"
+}
+
 declare module "bootstrap.native" {
-    import Alert from "bootstrap.native/dist/components/alert-native.esm.js";
-    import Button from "bootstrap.native/dist/components/button-native.esm.js";
-    import Carousel from "bootstrap.native/dist/components/carousel-native.esm.js";
-    import Collapse from "bootstrap.native/dist/components/collapse-native.esm.js";
-    import Dropdown from "bootstrap.native/dist/components/dropdown-native.esm.js";
-    import Modal from "bootstrap.native/dist/components/modal-native.esm.js";
-    import Popover from "bootstrap.native/dist/components/popover-native.esm.js";
-    import ScrollSpy from "bootstrap.native/dist/components/scrollspy-native.esm.js";
-    import Tab from "bootstrap.native/dist/components/tab-native.esm.js";
-    import Toast from "bootstrap.native/dist/components/toast-native.esm.js";
+    import Alert from "bootstrap.native/src/components/alert-native.js";
+    import Button from "bootstrap.native/src/components/button-native.js";
+    import Carousel from "bootstrap.native/src/components/carousel-native.js";
+    import Collapse from "bootstrap.native/src/components/collapse-native.js";
+    import Dropdown from "bootstrap.native/src/components/dropdown-native.js";
+    import Modal from "bootstrap.native/src/components/modal-native.js";
+    import Popover from "bootstrap.native/src/components/popover-native.js";
+    import ScrollSpy from "bootstrap.native/src/components/scrollspy-native.js";
+    import Tab from "bootstrap.native/src/components/tab-native.js";
+    import Toast from "bootstrap.native/src/components/toast-native.js";
 
     interface Components {
         Alert: typeof Alert;


### PR DESCRIPTION
I prepared typescript definitions for ES sources as discussed in https://github.com/thednp/bootstrap.native/pull/391#issuecomment-716539355.

I'm sorry it took me a while.

With this patch, these imports are possible and covered by TS definitions:

```ts
import Alert from "bootstrap.native/dist/components/alert-native.esm.js" // Same thing for other components
import Alert from "bootstrap.native/src/components/alert-native.js" // Same thing for other components
import BSN from "bootstrap.native"
```
---
I also added Tooltip to the default export of `bootstrap.native`, I forgot to include it in the original PR.