### PR TITLE
Fix issue where null collapse throws a type error

### DIFF
--- a/src/components/collapse-native.js
+++ b/src/components/collapse-native.js
@@ -125,7 +125,10 @@ export default function Collapse(element,options) {
     // determine targets
     collapse = queryElement(options.target || element.getAttribute('data-target') || element.getAttribute('href'));
     
-    collapse.isAnimating = false;  
+    if(collapse !== null) {
+      collapse.isAnimating = false;  
+    }
+  
     accordion = element.closest(options.parent || accordionData);
   
     // prevent adding event handlers twice


### PR DESCRIPTION
When compiled with typescript the following example from the documentation throws a type error because collapse is sometimes null:

```HTML
<button id="collapseButton" class="btn btn-primary" type="button" aria-expanded="false" aria-controls="collapseExample"
  data-toggle="collapse" data-target="#collapseExample"> <!-- required DATA API -->
  Button with data-target
</button>

<!-- and the basic collapsible template -->
<div class="collapse" id="collapseExample">
  <div class="card card-body">
    ...
  </div>
</div>
```


```TS

let myCollapseInit = new BSN.Collapse('#collapseLink')

```