### PR TITLE
fix: use object format of destructuring assignment

### DIFF
--- a/src/components-v4/popover-native.js
+++ b/src/components-v4/popover-native.js
@@ -49,11 +49,14 @@ export default function Popover(elem, opsInput) {
     }
   }
   // private methods
-  function getContents() {
-    return {
-      0: options.title || element.getAttribute('data-title') || null,
-      1: options.content || element.getAttribute('data-content') || null,
-    };
+  function getAttr(att) {
+    return options[att] || element.dataset[att] || null;
+  }
+  function getTitle() {
+    return getAttr('title');
+  }
+  function getContent() {
+    return getAttr('content');
   }
   function removePopover() {
     ops.container.removeChild(popover);
@@ -61,7 +64,8 @@ export default function Popover(elem, opsInput) {
   }
 
   function createPopover() {
-    [titleString, contentString] = getContents();
+    titleString = getTitle();
+    contentString = getContent();
     // fixing https://github.com/thednp/bootstrap.native/issues/233
     contentString = contentString ? contentString.trim() : null;
 
@@ -254,7 +258,8 @@ export default function Popover(elem, opsInput) {
   placementClass = `bs-popover-${ops.placement}`;
 
   // invalidate
-  [titleString, contentString] = getContents();
+  titleString = getTitle();
+  contentString = getContent();
 
   if (!contentString && !ops.template) return;
 


### PR DESCRIPTION
This small fix addresses #419, which was breaking popovers in v4, when used with either direct code or certain transpilers, such as babel. It modifies the return value to the `getContents()` helper function to return a keyed object for destructuring assignment, rather than a mocked array, which fails due to not being the proper iterator needed for array-form destructuring assignment. The effect was to break popovers unless you used the standard supplied v4 packages. 

I did consider changing `getContents()` to return an array, but that was more verbose when transpiled, and there was no point given that this is a fixed multiple-return-value pattern, not a variable multiple-return-value one.