### PR TITLE
fix accordion handling in collapse

### DIFF
--- a/src/components-v4/collapse-native.js
+++ b/src/components-v4/collapse-native.js
@@ -126,7 +126,12 @@ export default function Collapse(elem, opsInput) {
   collapse = queryElement(options.target || element.getAttribute('data-target') || element.getAttribute('href'));
 
   if (collapse !== null) collapse.isAnimating = false;
-  accordion = element.closest(options.parent || accordionData);
+  const accordionSelector = options.parent || accordionData;
+  if (accordionSelector) {
+    accordion = element.closest(accordionSelector);
+  } else {
+    accordion = null;
+  }
 
   // prevent adding event handlers twice
   if (!element.Collapse) {


### PR DESCRIPTION
This handles an issue with IE11, where `Element.closest()` is always called, even when there is no `parent` option or `data-target` attribute. 

In Chrome, Safari, Firefox, and even MS Edge, strangely, calling, e.g., `randomElement.closest(null)` returns null, despite the documentation that suggests it to be a syntax error (see: https://developer.mozilla.org/en-US/docs/Web/API/Element/closest). However, as far as I can tell, this is against the specification. I think assuming that passing null as a selector is okay also seems odd. 

I found this on IE11 with a polyfill for `Element.closest()` (IE11 doesn't natively support it anyway). There are a lot of different polyfills for `closest()` so it is not clear how likely this is in real life, so I won't be upset if you don't want this commit. I did check the original Bootstrap 4 code, and this also makes a conditional check here: https://github.com/twbs/bootstrap/blob/6ffb0b48e455430f8a5359ed689ad64c1143fac2/js/src/collapse.js#L320. So there is a case for this change.

This proposed change sets the accordion/data-target element only if a selector can be retrieved, otherwise null. 